### PR TITLE
Github Enterprise and OAuth authentication support

### DIFF
--- a/lib/omnifocus/github.rb
+++ b/lib/omnifocus/github.rb
@@ -22,10 +22,15 @@ module OmniFocus::Github
         next
       end
 
+      # process will omit the account label if nil.
+      # Supply nil for the default "github" account for compatibility
+      # with previous versions.
+      account_label = account == "github" ? nil : account
+
       body = fetch(api, auth, 1)
-      process(account, body)
+      process(account_label, body)
       (2..get_last(body)).each do |page|
-        process(account, fetch(api, auth, page))
+        process(account_label, fetch(api, auth, page))
       end
     end
   end
@@ -56,7 +61,7 @@ module OmniFocus::Github
       pr        = issue["pull_request"] && !issue["pull_request"]["diff_url"].nil?
       number    = issue["number"]
       url       = issue["html_url"]
-      project   = "#{account}-#{url.split(/\//)[-3]}"
+      project   = [account, url.split(/\//)[-3]].compact.join("-")
       ticket_id = "#{PREFIX}-#{project}##{number}"
       title     = "#{ticket_id}: #{pr ? "[PR] " : ""}#{issue["title"]}"
       note      = "#{url}\n\n#{issue["body"]}"


### PR DESCRIPTION
The git config key of omnifocus-github.accounts can
be specified as a whitespaces separated list of github
accounts.  By default, an account name of "github"
is used.

For each account, the API endpoint and authentication
parameters can be stored in the global git config
under a key matching the account.  For example, setting
up username/password authentication for gethub.com
and OAuth token authentication for a github enterprise
installation:

```
git config --global github.user me
git config --global github.password mypassword
git config --global myghe.api https://ghe.mydomain.com/api/v3
git config --global myghe.token 1a2b3c4d5e6f7e8d
```

Then tell omnifocus-github about them:

```
git config --global omnifocus-github.accounts "github myghe"
```

The details of parameters for each account:
- api - specify an API endpoint other than https://api.github.com.
  This is so you can point this at your Github Enterprise endpoint.
- user, password - A username and password pair for Basic
  http authentication.
- token - An OAuth bearer token for OAuth workflows.

If both a token and a username and password are supplied, the token
is used.
- Include "[PR]" in the task title of issues which are pull requests.
- Include the full issue body in the omnifocus issue.  Useful
  to have more data in OF in case your Github endpoint is on
  the wrong side of a firewall.
