### PR TITLE
Query git without forcing --global

### DIFF
--- a/lib/omnifocus/github.rb
+++ b/lib/omnifocus/github.rb
@@ -40,7 +40,7 @@ module OmniFocus::Github
   end
 
   def omnifocus_git_param name, default = nil, prefix = "omnifocus-github"
-    param = `git config --global #{prefix}.#{name}`.chomp
+    param = `git config #{prefix}.#{name}`.chomp
     param.empty? ? default : param
   end
 


### PR DESCRIPTION
Git allows you to `include` stuff in configs (to "assemble" multiple git config files) , but it doesn't do it when you call git with `--global` (or any other restriction like that). It'd simply ignore your includes. If we just need to query git for a config value, best to do it without imposing where they should be stored.